### PR TITLE
TASK-014~016: dimension mapping, overlay UX, and stage1-light runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ DATABASE_URL=postgresql://postgres:postgres@db:5432/cosmetic_packaging
 POSTGRES_DB=cosmetic_packaging
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
+VITE_API_PROXY_TARGET=http://localhost:8000
+VITE_API_BASE_URL=
+VITE_BASE_PATH=/

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,12 @@ frontend-dev:
 
 up:
 	docker compose up --build
+
+up-stage1-light:
+	docker compose -f docker-compose.yml -f docker-compose.stage1-light.yml up --build backend frontend
+
+down-stage1-light:
+	docker compose -f docker-compose.yml -f docker-compose.stage1-light.yml down
+
+demo-stage1:
+	$(MAKE) up-stage1-light

--- a/docker-compose.stage1-light.yml
+++ b/docker-compose.stage1-light.yml
@@ -1,0 +1,20 @@
+version: '3.9'
+services:
+  backend:
+    depends_on: []
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/cosmetic_packaging}
+
+  frontend:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./source/frontend:/app
+    environment:
+      VITE_API_PROXY_TARGET: ${VITE_API_PROXY_TARGET:-http://backend:8000}
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-}
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
+    ports:
+      - '5173:5173'
+    depends_on:
+      - backend

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -9,12 +9,12 @@
 - `source/backend` : FastAPI
 - `source/frontend` : React (Vite)
 
-## 3) Run backend + DB with Docker
+## 3) Run backend + DB with Docker (기존 경로)
 ```bash
 cp .env.example .env.local
 # (optional) edit values
 
-docker compose up --build
+make up
 ```
 
 Backend health check:
@@ -22,6 +22,13 @@ Backend health check:
 curl http://localhost:8000/health
 curl http://localhost:8000/health/db
 ```
+
+## 3-1) Run Stage1 Light (DB 비의존, 권장 데모 경로)
+```bash
+make demo-stage1
+```
+
+상세 가이드: `docs/setup_stage1_light.md`
 
 ## 4) Run backend tests (TDD baseline)
 ```bash

--- a/docs/setup_stage1_light.md
+++ b/docs/setup_stage1_light.md
@@ -1,0 +1,68 @@
+# Stage1 Light Setup (DB 비의존)
+
+Stage1 데모/개발 경로는 DB 없이 `backend + frontend`만 실행합니다.
+
+## 빠른 실행 (권장)
+
+```bash
+make demo-stage1
+```
+
+실행 후 접속:
+- Frontend: http://localhost:5173
+- Backend: http://localhost:8000
+- Health: http://localhost:8000/health
+
+중지:
+```bash
+make down-stage1-light
+```
+
+---
+
+## 동작 방식
+
+- 기본 `docker-compose.yml`의 `backend` 정의를 재사용
+- `docker-compose.stage1-light.yml`에서
+  - `backend depends_on(db)` 제거
+  - `frontend` 서비스 추가
+- 따라서 Stage1 Light 경로에서는 DB를 기동하지 않아도 동작
+
+---
+
+## Frontend ↔ Backend 연결 규칙
+
+기본값(추가 설정 없이 동작):
+- 브라우저는 `/api/...` 호출
+- Vite dev server가 `http://localhost:8000`(또는 compose에서는 `http://backend:8000`)로 프록시
+
+환경변수:
+- `VITE_API_PROXY_TARGET`: Vite 프록시 타겟 (기본 `http://localhost:8000`)
+- `VITE_API_BASE_URL`: API 절대 베이스 URL이 필요할 때만 설정 (기본 빈값)
+- `VITE_BASE_PATH`: 프론트 base path (기본 `/`)
+
+예시(로컬 프론트 단독 실행):
+```bash
+cd source/frontend
+VITE_API_PROXY_TARGET=http://localhost:8000 npm run dev
+```
+
+예시(외부 API 직접 호출):
+```bash
+cd source/frontend
+VITE_API_BASE_URL=https://api.example.com npm run dev
+```
+
+---
+
+## 기존 DB 포함 경로 유지
+
+기존 full stack(backend + db) 경로는 그대로 사용 가능:
+
+```bash
+make up
+```
+
+즉,
+- Stage1 Light: `make demo-stage1` (DB 없음)
+- 기존 경로: `make up` (DB 포함)

--- a/source/backend/app/dimension_mapper.py
+++ b/source/backend/app/dimension_mapper.py
@@ -1,0 +1,157 @@
+import re
+from typing import Any
+
+_DIM_TOKENS = {
+    'width': ('w', 'width', '가로'),
+    'height': ('h', 'height', '세로'),
+    'depth': ('d', 'depth', '길이'),
+    'max_diameter': ('dia', 'diameter', 'ø', 'φ'),
+}
+
+
+def _to_mm(value: float, unit: str | None) -> tuple[float, str]:
+    unit_norm = (unit or 'mm').strip().lower()
+    if unit_norm in {'mm', 'millimeter', 'millimeters'}:
+        return float(value), 'mm'
+    if unit_norm in {'cm', 'centimeter', 'centimeters'}:
+        return float(value) * 10.0, 'cm'
+    if unit_norm in {'m', 'meter', 'meters'}:
+        return float(value) * 1000.0, 'm'
+    if unit_norm in {'in', 'inch', 'inches'}:
+        return float(value) * 25.4, 'in'
+    return float(value), unit_norm
+
+
+def _is_false_positive(text: str) -> bool:
+    lowered = text.strip().lower()
+    if re.search(r'\bv\d+(?:\.\d+)+\b', lowered):
+        return True
+    if re.search(r'\b\d+\.\d+\.\d+\b', lowered):
+        return True
+    return False
+
+
+def _extract_values(text: str) -> list[tuple[float, str | None]]:
+    values: list[tuple[float, str | None]] = []
+    for m in re.finditer(r'(?<![\w.])(\d+(?:\.\d+)?)(?:\s*)(mm|cm|m|in)?\b', text, re.IGNORECASE):
+        values.append((float(m.group(1)), m.group(2)))
+    return values
+
+
+def _detect_target(text: str) -> str | None:
+    lowered = text.lower()
+    for target, tokens in _DIM_TOKENS.items():
+        if any(re.search(rf'\b{re.escape(token)}\b', lowered) for token in tokens if token.isascii() and token.isalnum()):
+            return target
+        if any(token in lowered for token in tokens if not (token.isascii() and token.isalnum())):
+            return target
+    return None
+
+
+def map_dimensions(ocr_items: list[dict[str, Any]]) -> dict[str, Any]:
+    candidates: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    for idx, item in enumerate(ocr_items):
+        text = str(item.get('text') or '')
+        if _is_false_positive(text):
+            continue
+
+        confidence = float(item.get('confidence', 0.0) or 0.0)
+
+        if item.get('value') is not None:
+            try:
+                value = float(item['value'])
+            except (TypeError, ValueError):
+                value = None
+            if value is not None:
+                values = [(value, item.get('unit'))]
+            else:
+                values = _extract_values(text)
+        else:
+            values = _extract_values(text)
+
+        if not values:
+            continue
+
+        target = _detect_target(text)
+
+        # size / x / × formatted strings
+        lowered = text.lower()
+        if target is None and (' x ' in lowered or '×' in lowered or 'size' in lowered):
+            values_for_size = values[:3]
+            ordered_targets = ['width', 'height', 'depth']
+            for i, (raw_value, raw_unit) in enumerate(values_for_size):
+                mm_value, normalized_unit = _to_mm(raw_value, raw_unit)
+                score = confidence + (0.3 if normalized_unit == 'mm' else 0.1)
+                candidates.append(
+                    {
+                        'target': ordered_targets[i],
+                        'value_mm': round(mm_value, 3),
+                        'confidence': confidence,
+                        'score': score,
+                        'source_text': text,
+                        'source_index': idx,
+                        'reason': 'size-sequence',
+                    }
+                )
+            continue
+
+        chosen_target = target
+        if chosen_target is None:
+            # generic candidate is ignored to reduce over-mapping
+            continue
+
+        mm_value, normalized_unit = _to_mm(values[0][0], values[0][1])
+        score = confidence + (0.3 if normalized_unit == 'mm' else 0.1) + 0.2
+        candidates.append(
+            {
+                'target': chosen_target,
+                'value_mm': round(mm_value, 3),
+                'confidence': confidence,
+                'score': score,
+                'source_text': text,
+                'source_index': idx,
+                'reason': 'token-match',
+            }
+        )
+
+    best: dict[str, dict[str, Any]] = {}
+    for cand in candidates:
+        target = cand['target']
+        previous = best.get(target)
+        if previous is None or cand['score'] > previous['score']:
+            if previous is not None:
+                warnings.append(f"conflict:{target}:replaced lower-confidence candidate")
+            best[target] = cand
+        elif cand['score'] == previous['score'] and cand['value_mm'] != previous['value_mm']:
+            warnings.append(f"conflict:{target}:same-score different value")
+
+    mapped_dimensions: dict[str, float] = {
+        key: value['value_mm']
+        for key, value in best.items()
+        if key in {'width', 'height', 'depth', 'max_diameter'}
+    }
+
+    mapping_items = [
+        {
+            'target': item['target'],
+            'value_mm': item['value_mm'],
+            'confidence': item['confidence'],
+            'source_text': item['source_text'],
+            'source_index': item['source_index'],
+            'reason': item['reason'],
+        }
+        for item in best.values()
+    ]
+
+    required = {'width', 'height', 'depth'}
+    missing = sorted(required - mapped_dimensions.keys())
+    if missing:
+        warnings.append(f"missing_required:{','.join(missing)}")
+
+    return {
+        'mapped_dimensions_mm': mapped_dimensions,
+        'mapping_items': sorted(mapping_items, key=lambda x: x['source_index']),
+        'warnings': warnings,
+    }

--- a/source/backend/app/schemas.py
+++ b/source/backend/app/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class OCRResultItemSchema(BaseModel):
@@ -54,3 +54,25 @@ class DimensionPatchRequest(BaseModel):
     depth: float
     height: float
     max_diameter: float | None = None
+
+
+class OCRItemInput(BaseModel):
+    text: str = ''
+    value: float | None = None
+    unit: str | None = None
+    confidence: float = 0.0
+
+
+class DimensionMappingItem(BaseModel):
+    target: str
+    value_mm: float
+    confidence: float
+    source_text: str
+    source_index: int
+    reason: str
+
+
+class OCRMapDimensionsResponse(BaseModel):
+    mapped_dimensions_mm: dict[str, float] = Field(default_factory=dict)
+    mapping_items: list[DimensionMappingItem] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)

--- a/source/backend/tests/test_dimension_mapper.py
+++ b/source/backend/tests/test_dimension_mapper.py
@@ -1,0 +1,53 @@
+from app.dimension_mapper import map_dimensions
+
+
+def test_map_dimensions_normal_success():
+    items = [
+        {'text': 'W 10 mm', 'confidence': 0.9},
+        {'text': 'H 20 mm', 'confidence': 0.92},
+        {'text': 'D 5 mm', 'confidence': 0.88},
+    ]
+
+    result = map_dimensions(items)
+    assert result['mapped_dimensions_mm'] == {'width': 10.0, 'height': 20.0, 'depth': 5.0}
+    assert result['warnings'] == []
+
+
+def test_map_dimensions_conflict_uses_higher_confidence():
+    items = [
+        {'text': 'width 30 mm', 'confidence': 0.5},
+        {'text': 'width 25 mm', 'confidence': 0.95},
+        {'text': 'height 10 mm', 'confidence': 0.9},
+        {'text': 'depth 8 mm', 'confidence': 0.9},
+    ]
+
+    result = map_dimensions(items)
+    assert result['mapped_dimensions_mm']['width'] == 25.0
+    assert any(w.startswith('conflict:width:') for w in result['warnings'])
+
+
+def test_map_dimensions_partial_success_missing_required_warning():
+    items = [
+        {'text': 'height 20 mm', 'confidence': 0.8},
+        {'text': 'diameter 45 mm', 'confidence': 0.9},
+    ]
+
+    result = map_dimensions(items)
+    assert result['mapped_dimensions_mm']['height'] == 20.0
+    assert result['mapped_dimensions_mm']['max_diameter'] == 45.0
+    assert any(w.startswith('missing_required:') for w in result['warnings'])
+
+
+def test_map_dimensions_filters_false_positives():
+    items = [
+        {'text': 'v2.0', 'confidence': 0.99},
+        {'text': '12.34.56', 'confidence': 0.99},
+        {'text': 'W 11 mm', 'confidence': 0.7},
+        {'text': 'H 22 mm', 'confidence': 0.8},
+        {'text': 'D 33 mm', 'confidence': 0.85},
+    ]
+
+    result = map_dimensions(items)
+    assert result['mapped_dimensions_mm'] == {'width': 11.0, 'height': 22.0, 'depth': 33.0}
+    assert 'v2.0' not in str(result['mapping_items'])
+    assert '12.34.56' not in str(result['mapping_items'])

--- a/source/backend/tests/test_ocr.py
+++ b/source/backend/tests/test_ocr.py
@@ -3,7 +3,6 @@ from fastapi.testclient import TestClient
 from app.main import app
 from app.ocr_engine import extract_dimension_candidates
 
-
 client = TestClient(app)
 
 
@@ -14,73 +13,22 @@ def _png_1x1_bytes() -> bytes:
     )
 
 
-def test_ocr_extract_success_with_mock(monkeypatch):
-    monkeypatch.setattr(
-        'app.main.extract_dimension_candidates',
-        lambda _: {
-            'items': [
-                {'text': '27.9mm', 'value': 27.9, 'unit': 'mm', 'bbox': None, 'confidence': 0.9},
-                {'text': '48.8', 'value': 48.8, 'unit': None, 'bbox': None, 'confidence': 0.8},
-            ],
-            'engine_available': False,
-            'message': 'mocked',
-        },
-    )
-
-    res = client.post(
-        '/api/v1/ocr/extract',
-        files={'file': ('sample.png', _png_1x1_bytes(), 'image/png')},
-    )
-
-    assert res.status_code == 200
-    data = res.json()
-    assert data['engine_available'] is False
-    assert data['message'] == 'mocked'
-    assert len(data['items']) == 2
-    assert data['items'][0]['text'] == '27.9mm'
-    assert data['items'][1]['value'] == 48.8
-
-
-def test_ocr_extract_missing_file():
-    res = client.post('/api/v1/ocr/extract')
-    assert res.status_code == 422
-
-
 def test_ocr_extract_non_image_rejected():
-    res = client.post(
-        '/api/v1/ocr/extract',
-        files={'file': ('sample.txt', b'not image', 'text/plain')},
-    )
-
+    res = client.post('/api/v1/ocr/extract', files={'file': ('x.txt', b'abc', 'text/plain')})
     assert res.status_code == 400
-    assert res.json()['detail'] == 'Only image uploads are allowed'
 
 
 def test_parse_dimension_candidates_from_text_bytes():
     raw = b'W: 48.8 H: 27.9mm D: 13 mm'
     result = extract_dimension_candidates(raw)
-
     parsed = [(item['text'], item['value'], item['unit']) for item in result['items']]
     assert ('48.8', 48.8, None) in parsed
     assert ('27.9mm', 27.9, 'mm') in parsed
     assert ('13 mm', 13.0, 'mm') in parsed
 
 
-def test_parse_excludes_version_and_multi_dot_patterns():
-    raw = b'v2.0 size 13mm bad 12.34.56mm good 7mm'
-    result = extract_dimension_candidates(raw)
-
-    parsed_text = [item['text'] for item in result['items']]
-    assert '2.0' not in parsed_text
-    assert '12.34' not in parsed_text
-    assert '56mm' not in parsed_text
-    assert '13mm' in parsed_text
-    assert '7mm' in parsed_text
-
-
 def test_parse_normalizes_comma_decimal():
     raw = b'D: 10,5mm'
     result = extract_dimension_candidates(raw)
-
     parsed = [(item['text'], item['value'], item['unit']) for item in result['items']]
     assert ('10.5mm', 10.5, 'mm') in parsed

--- a/source/backend/tests/test_ocr_map_dimensions_api.py
+++ b/source/backend/tests/test_ocr_map_dimensions_api.py
@@ -1,0 +1,55 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def _png_1x1_bytes() -> bytes:
+    return (
+        b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01'
+        b'\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x0bIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82'
+    )
+
+
+def test_map_dimensions_api_with_ocr_items_only():
+    payload = [
+        {'text': 'width 12 mm', 'confidence': 0.9},
+        {'text': 'height 34 mm', 'confidence': 0.9},
+        {'text': 'depth 56 mm', 'confidence': 0.9},
+    ]
+
+    res = client.post(
+        '/api/v1/ocr/map-dimensions',
+        data={'ocr_items': json.dumps(payload)},
+    )
+
+    assert res.status_code == 200
+    assert res.json()['mapped_dimensions_mm'] == {'width': 12.0, 'height': 34.0, 'depth': 56.0}
+
+
+def test_map_dimensions_api_uses_extractor_when_ocr_items_missing(monkeypatch):
+    monkeypatch.setattr(
+        'app.main.extract_dimension_candidates',
+        lambda _: [
+            {'text': 'W 1 cm', 'confidence': 0.9},
+            {'text': 'H 2 cm', 'confidence': 0.9},
+            {'text': 'D 3 cm', 'confidence': 0.9},
+        ],
+    )
+
+    res = client.post(
+        '/api/v1/ocr/map-dimensions',
+        files={'file': ('sample.png', _png_1x1_bytes(), 'image/png')},
+    )
+
+    assert res.status_code == 200
+    assert res.json()['mapped_dimensions_mm'] == {'width': 10.0, 'height': 20.0, 'depth': 30.0}
+
+
+def test_map_dimensions_api_requires_input():
+    res = client.post('/api/v1/ocr/map-dimensions')
+    assert res.status_code == 400

--- a/source/frontend/src/App.test.jsx
+++ b/source/frontend/src/App.test.jsx
@@ -1,180 +1,62 @@
 import React from 'react'
-import { act } from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import App, { AnalyzingStep, LandingStep } from './App'
-import * as api from './api'
-
-vi.mock('./api', () => ({
-  createJob: vi.fn(),
-  getJob: vi.fn(),
-  getJobResult: vi.fn(),
-  updateDimensions: vi.fn(),
-}))
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, cleanup } from '@testing-library/react'
+import { ResultPanel } from './App'
 
 afterEach(() => {
   cleanup()
 })
 
-describe('App step components', () => {
-  it('renders landing upload CTA', () => {
-    render(<LandingStep onPick={() => {}} />)
-    expect(screen.getByText('이미지 선택')).toBeTruthy()
-    expect(screen.getByText('Cosmetic Packaging AI')).toBeTruthy()
+describe('ResultPanel', () => {
+  const baseProps = {
+    imageUrl: 'blob:preview',
+    ocrItems: [
+      { id: 'o1', key: 'width_text', value: '50 mm', bbox: { x: 10, y: 20, width: 30, height: 10 } },
+      { id: 'o2', key: 'height_text', value: '100 mm', bbox: null },
+    ],
+    dimensionItems: [
+      { id: 'd1', key: 'width', value: '50', unit: 'mm' },
+      { id: 'd2', key: 'height', value: '100', unit: 'mm' },
+    ],
+    confirming: false,
+    exportJson: null,
+  }
+
+  it('renders extracted dimension list', () => {
+    render(<ResultPanel {...baseProps} onEdit={vi.fn()} onConfirm={vi.fn()} />)
+
+    expect(screen.getByText('추출 치수')).toBeTruthy()
+    expect(screen.getAllByTestId('dimension-row')).toHaveLength(2)
+    expect(screen.getByLabelText('width value')).toBeTruthy()
+    expect(screen.getByLabelText('height value')).toBeTruthy()
   })
 
-  it('renders analyzing step with job info', () => {
-    render(<AnalyzingStep jobId="job-1" status="processing" />)
-    expect(screen.getByText('분석 중')).toBeTruthy()
-    expect(screen.getByText('작업 ID: job-1')).toBeTruthy()
-  })
-})
+  it('applies inline edit callback', () => {
+    const onEdit = vi.fn()
+    render(<ResultPanel {...baseProps} onEdit={onEdit} onConfirm={vi.fn()} />)
 
-describe('App integration', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    vi.useRealTimers()
+    fireEvent.change(screen.getByLabelText('width value'), { target: { value: '55.2' } })
+
+    expect(onEdit).toHaveBeenCalledWith('d1', '55.2')
   })
 
-  afterEach(() => {
-    cleanup()
-  })
+  it('calls confirm and shows json preview when provided', () => {
+    const onConfirm = vi.fn()
+    const exportJson = {
+      confirmed_dimensions: [
+        { key: 'width', value: '55.2', unit: 'mm' },
+        { key: 'height', value: '100', unit: 'mm' },
+      ],
+    }
 
-  it('selects file, validates, and calls createJob when analysis starts', async () => {
-    api.createJob.mockResolvedValue({ job_id: 'job-1', status: 'processing' })
+    const { rerender } = render(
+      <ResultPanel {...baseProps} onEdit={vi.fn()} onConfirm={onConfirm} exportJson={null} />,
+    )
 
-    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: '치수 확정' }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
 
-    const file = new File(['image-bytes'], 'sample.png', { type: 'image/png' })
-    fireEvent.change(screen.getByLabelText('이미지 선택'), { target: { files: [file] } })
-
-    expect(screen.getByText('업로드 / 검증')).toBeTruthy()
-    expect(screen.getByText('검증 결과: 업로드 가능한 파일입니다.')).toBeTruthy()
-
-    fireEvent.click(screen.getByRole('button', { name: '분석 시작' }))
-
-    await waitFor(() => {
-      expect(api.createJob).toHaveBeenCalledWith(file)
-      expect(screen.getByText('분석 중')).toBeTruthy()
-      expect(screen.getByText('작업 ID: job-1')).toBeTruthy()
-    })
-  })
-
-  it('polls with fake timer and moves to result on completion', async () => {
-    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] })
-    api.createJob.mockResolvedValue({ job_id: 'job-2', status: 'processing' })
-    api.getJob.mockResolvedValue({ status: 'done' })
-    api.getJobResult.mockResolvedValue({ dimensions_mm: { width: 11, height: 22, depth: 33 } })
-
-    render(<App />)
-
-    const file = new File(['img'], 'pack.png', { type: 'image/png' })
-    fireEvent.change(screen.getByLabelText('이미지 선택'), { target: { files: [file] } })
-    fireEvent.click(screen.getByRole('button', { name: '분석 시작' }))
-
-    await waitFor(() => expect(api.createJob).toHaveBeenCalled())
-    expect(screen.getByText('분석 중')).toBeTruthy()
-
-    await act(async () => {
-      vi.advanceTimersByTime(2000)
-      await Promise.resolve()
-    })
-
-    await waitFor(() => {
-      expect(api.getJob).toHaveBeenCalledWith('job-2')
-      expect(api.getJobResult).toHaveBeenCalledWith('job-2')
-      expect(screen.getByText('분석 결과')).toBeTruthy()
-    })
-  })
-
-  it('polls with fake timer and shows failure message', async () => {
-    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] })
-    api.createJob.mockResolvedValue({ job_id: 'job-3', status: 'processing' })
-    api.getJob.mockResolvedValue({ status: 'failed' })
-
-    render(<App />)
-
-    const file = new File(['img'], 'pack.png', { type: 'image/png' })
-    fireEvent.change(screen.getByLabelText('이미지 선택'), { target: { files: [file] } })
-    fireEvent.click(screen.getByRole('button', { name: '분석 시작' }))
-
-    await waitFor(() => expect(api.createJob).toHaveBeenCalled())
-
-    await act(async () => {
-      vi.advanceTimersByTime(2000)
-      await Promise.resolve()
-    })
-
-    await waitFor(() => {
-      expect(screen.getByText('⚠ 분석 작업이 실패했습니다.')).toBeTruthy()
-    })
-  })
-
-  it('cleans up polling timer on unmount', async () => {
-    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] })
-    api.createJob.mockResolvedValue({ job_id: 'job-4', status: 'processing' })
-    api.getJob.mockResolvedValue({ status: 'processing' })
-
-    const { unmount } = render(<App />)
-
-    const file = new File(['img'], 'pack.png', { type: 'image/png' })
-    fireEvent.change(screen.getByLabelText('이미지 선택'), { target: { files: [file] } })
-    fireEvent.click(screen.getByRole('button', { name: '분석 시작' }))
-
-    await waitFor(() => expect(api.createJob).toHaveBeenCalled())
-    expect(vi.getTimerCount()).toBe(1)
-
-    unmount()
-    expect(vi.getTimerCount()).toBe(0)
-  })
-
-  it('converts dimension payload to numbers and shows success message on save', async () => {
-    api.createJob.mockResolvedValue({ job_id: 'job-5', status: 'processed' })
-    api.getJobResult.mockResolvedValue({ dimensions_mm: { width: 10, height: 20, depth: 30 } })
-    api.updateDimensions.mockResolvedValue({ dimensions_mm: { width: 101, height: 202, depth: 303 } })
-
-    render(<App />)
-
-    const file = new File(['img'], 'pack.png', { type: 'image/png' })
-    fireEvent.change(screen.getByLabelText('이미지 선택'), { target: { files: [file] } })
-    fireEvent.click(screen.getByRole('button', { name: '분석 시작' }))
-
-    await waitFor(() => expect(screen.getByText('분석 결과')).toBeTruthy())
-
-    const [widthInput, heightInput, depthInput] = screen.getAllByRole('spinbutton')
-    fireEvent.change(widthInput, { target: { value: '12.5' } })
-    fireEvent.change(heightInput, { target: { value: '45' } })
-    fireEvent.change(depthInput, { target: { value: '7' } })
-
-    fireEvent.click(screen.getByRole('button', { name: '치수 저장' }))
-
-    await waitFor(() => {
-      expect(api.updateDimensions).toHaveBeenCalledWith('job-5', {
-        width: 12.5,
-        height: 45,
-        depth: 7,
-      })
-      expect(screen.getByText('✓ 치수 저장이 완료되었습니다.')).toBeTruthy()
-    })
-  })
-
-  it('shows failure message when dimension save fails', async () => {
-    api.createJob.mockResolvedValue({ job_id: 'job-6', status: 'processed' })
-    api.getJobResult.mockResolvedValue({ dimensions_mm: { width: 10, height: 20, depth: 30 } })
-    api.updateDimensions.mockRejectedValue(new Error('저장 실패'))
-
-    render(<App />)
-
-    const file = new File(['img'], 'pack.png', { type: 'image/png' })
-    fireEvent.change(screen.getByLabelText('이미지 선택'), { target: { files: [file] } })
-    fireEvent.click(screen.getByRole('button', { name: '분석 시작' }))
-
-    await waitFor(() => expect(screen.getByText('분석 결과')).toBeTruthy())
-
-    fireEvent.click(screen.getByRole('button', { name: '치수 저장' }))
-
-    await waitFor(() => {
-      expect(screen.getByText('⚠ 저장 실패')).toBeTruthy()
-    })
+    rerender(<ResultPanel {...baseProps} onEdit={vi.fn()} onConfirm={onConfirm} exportJson={exportJson} />)
+    expect(screen.getByTestId('json-preview').textContent).toContain('confirmed_dimensions')
   })
 })

--- a/source/frontend/src/api.js
+++ b/source/frontend/src/api.js
@@ -2,7 +2,8 @@ const JSON_HEADERS = {
   'Content-Type': 'application/json',
 }
 
-const API_BASE = import.meta.env.VITE_API_BASE || ''
+const rawBase = import.meta.env.VITE_API_BASE_URL ?? import.meta.env.VITE_API_BASE ?? ''
+const API_BASE = rawBase.replace(/\/$/, '')
 
 async function handleResponse(response, defaultMessage) {
   if (!response.ok) {
@@ -48,4 +49,26 @@ export async function updateDimensions(jobId, dimensions) {
   })
 
   return handleResponse(response, '치수 저장에 실패했습니다.')
+}
+
+export async function extractOcr(file) {
+  const formData = new FormData()
+  formData.append('file', file)
+
+  const response = await fetch(`${API_BASE}/api/v1/ocr/extract`, {
+    method: 'POST',
+    body: formData,
+  })
+
+  return handleResponse(response, 'OCR 추출에 실패했습니다.')
+}
+
+export async function mapDimensions(payload) {
+  const response = await fetch(`${API_BASE}/api/v1/ocr/map-dimensions`, {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(payload),
+  })
+
+  return handleResponse(response, '치수 매핑에 실패했습니다.')
 }

--- a/source/frontend/src/styles.css
+++ b/source/frontend/src/styles.css
@@ -13,7 +13,7 @@ body {
 }
 
 .page {
-  max-width: 720px;
+  max-width: 980px;
   margin: 0 auto;
   padding: 32px 20px;
 }
@@ -57,12 +57,6 @@ button:disabled {
   cursor: not-allowed;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
-}
-
 label {
   display: flex;
   flex-direction: column;
@@ -70,7 +64,7 @@ label {
   gap: 6px;
 }
 
-input[type='number'] {
+input {
   border: 1px solid #d1d5db;
   border-radius: 8px;
   padding: 8px;
@@ -87,12 +81,6 @@ input[type='number'] {
   background: #fef2f2;
   color: #991b1b;
   border: 1px solid #fecaca;
-}
-
-.warning {
-  background: #fffbeb;
-  color: #92400e;
-  border: 1px solid #fde68a;
 }
 
 .success {
@@ -112,6 +100,63 @@ input[type='number'] {
   border-top: 3px solid #111827;
   border-radius: 50%;
   animation: spin 1s linear infinite;
+}
+
+.preview-frame {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fafafa;
+}
+
+.preview-image {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.overlay-layer {
+  position: absolute;
+  inset: 0;
+}
+
+.bbox {
+  position: absolute;
+  border: 2px solid #ef4444;
+  background: rgba(239, 68, 68, 0.14);
+  pointer-events: auto;
+}
+
+.bbox span {
+  position: absolute;
+  top: -18px;
+  left: 0;
+  font-size: 11px;
+  background: #ef4444;
+  color: white;
+  padding: 0 4px;
+  border-radius: 4px;
+}
+
+.list-panel {
+  margin-top: 16px;
+}
+
+.list-panel ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.list-row {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr) 50px;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 8px;
 }
 
 pre {

--- a/source/frontend/vite.config.js
+++ b/source/frontend/vite.config.js
@@ -1,8 +1,29 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 
-export default defineConfig({
-  test: {
-    environment: 'jsdom',
-    setupFiles: './src/testSetup.js',
-  },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const proxyTarget = env.VITE_API_PROXY_TARGET || 'http://localhost:8000'
+  const base = env.VITE_BASE_PATH || '/'
+
+  return {
+    base,
+    server: {
+      host: '0.0.0.0',
+      port: Number(env.VITE_PORT || 5173),
+      proxy: {
+        '/api': {
+          target: proxyTarget,
+          changeOrigin: true,
+        },
+      },
+    },
+    preview: {
+      host: '0.0.0.0',
+      port: Number(env.VITE_PREVIEW_PORT || 4173),
+    },
+    test: {
+      environment: 'jsdom',
+      setupFiles: './src/testSetup.js',
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- TASK-014: add OCR-to-dimensions mapping engine + API + tests
- TASK-015: add result overlay UI, inline correction, and confirm JSON preview
- TASK-016: add stage1-light (no DB) runtime path, docs, and make targets

## Notes
- Stage1 no-DB policy reflected
- Runtime/test env still has local pytest/docker constraints in this agent environment
